### PR TITLE
Remove redundant titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug on Minehut
-title: "[BUG]: "
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,5 @@
 name: Feature Suggestion
 description: Suggest an feature for Minehut
-title: "[FEATURE]: "
 labels: ["feature request"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/filter.yml
+++ b/.github/ISSUE_TEMPLATE/filter.yml
@@ -1,5 +1,4 @@
 name: Filter Request
-title: "[FILTER]: "
 labels: filter request
 description: Report an issue with the filter
 body:


### PR DESCRIPTION
We already have a label assigned to each issue, no need for it to be in the title as well.